### PR TITLE
Fix election progress readout

### DIFF
--- a/web/src/routes/stats/+page.svelte
+++ b/web/src/routes/stats/+page.svelte
@@ -19,7 +19,7 @@
 		withCredentials: true,
 	});
 	eventSource.addEventListener("vote-received", (e) => {
-		numberOfVotes += parseInt(e.data, 10);
+		numberOfVotes = parseInt(e.data, 10);
 	});
 
 	const endElection = async () => {
@@ -67,8 +67,8 @@
 		<div class="container">
 			<h3>{numberOfVotes} of {$currentElection?.numEligibleVoters} users have voted so far</h3>
 			<p>
-				The turnout so far is {(numberOfVotes * 100) /
-					($currentElection?.numEligibleVoters ?? 100)}%
+				The turnout so far is {((numberOfVotes * 100) /
+					($currentElection?.numEligibleVoters ?? 100)).toFixed(2)}%
 			</p>
 			<Button
 				text="End election and view results"


### PR DESCRIPTION
Changes `/stats` to use absolute number of votes recieved provided by the backend instead of accumulating that value. Also rounds the percentage readout to 2 decimal points.

Fixes #23
Fixes #10