### PR TITLE
Remove global administrator users

### DIFF
--- a/internal/database/20240109215943_administrators.go
+++ b/internal/database/20240109215943_administrators.go
@@ -1,0 +1,34 @@
+package database
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/mattn/go-sqlite3"
+	"github.com/uptrace/bun"
+	"log/slog"
+)
+
+func init() {
+	Migrations.MustRegister(
+		func(ctx context.Context, db *bun.DB) error {
+			if _, err := db.NewRaw(`ALTER TABLE "users" ADD COLUMN "is_admin" BOOLEAN;`).Exec(ctx); err != nil {
+				var e sqlite3.Error
+				if errors.As(err, &e) {
+					if err.(sqlite3.Error).Code == 1 {
+						// assume this is due to a duplicate column
+						return nil
+					}
+				}
+				return fmt.Errorf("alter User table: %w", err)
+			}
+
+			slog.Warn("If you have just upgraded society-voting from a previous version, you will now need to manually edit the database to create some administrator users.")
+
+			return nil
+		},
+		func(ctx context.Context, db *bun.DB) error {
+			return nil
+		},
+	)
+}

--- a/internal/database/user.go
+++ b/internal/database/user.go
@@ -15,6 +15,7 @@ type User struct {
 	Name         string `json:"name"`
 	PasswordHash []byte `json:"-"`
 	IsRestricted bool   `json:"isRestricted"`
+	IsAdmin      bool   `json:"isAdmin"`
 }
 
 func (u *User) Insert(x ...bun.IDB) error {

--- a/internal/guildScraper/checkMember_noscrape.go
+++ b/internal/guildScraper/checkMember_noscrape.go
@@ -8,9 +8,14 @@ func init() {
 	slog.Warn("Built with noscrape tag (fictional user information will be used)")
 }
 
+var hasAdmined = false
+
 func GetMember(studentID string) (*GuildMember, error) {
+	isAdmin := !hasAdmined
+	hasAdmined = true
 	return &GuildMember{
-		ID:   studentID,
-		Name: "Martin Martinson",
+		ID:                studentID,
+		Name:              "Martin Martinson",
+		IsCommitteeMember: isAdmin,
 	}, nil
 }

--- a/internal/guildScraper/guildScraper.go
+++ b/internal/guildScraper/guildScraper.go
@@ -13,7 +13,8 @@ import (
 
 type GuildMember struct {
 	ID                string
-	Name              string
+	FirstName         string
+	LastName          string
 	IsCommitteeMember bool
 }
 
@@ -26,12 +27,6 @@ func GetMembersList() ([]*GuildMember, error) {
 	res, err := parseGuildMemberPage(pageData)
 	if err != nil {
 		return nil, fmt.Errorf("parse guild membership list: %w", err)
-	}
-
-	// Rewrite names from `Bloggs, Joe` to `Joe Bloggs`
-	for _, x := range res {
-		ns := strings.Split(x.Name, ", ")
-		x.Name = ns[1] + " " + ns[0]
 	}
 
 	return res, nil
@@ -121,10 +116,14 @@ func parseGuildMemberPage(pageData string) ([]*GuildMember, error) {
 	var res []*GuildMember
 
 	for id, name := range members {
+		// Last name comes first
+		ns := strings.Split(name, ", ")
+
 		_, isCmt := cmtMembers[id]
 		res = append(res, &GuildMember{
 			ID:                id,
-			Name:              name,
+			FirstName:         ns[1],
+			LastName:          ns[0],
 			IsCommitteeMember: isCmt,
 		})
 	}

--- a/internal/httpcore/endpoints_adminapi_elections.go
+++ b/internal/httpcore/endpoints_adminapi_elections.go
@@ -13,7 +13,7 @@ import (
 )
 
 func (endpoints) apiAdminCreateElection(ctx *fiber.Ctx) error {
-	if _, ok := getSessionAuth(ctx, authAdminUser); !ok {
+	if _, status := getSessionAuth(ctx); status&authAdminUser == 0 {
 		return fiber.ErrUnauthorized
 	}
 
@@ -39,7 +39,7 @@ func (endpoints) apiAdminCreateElection(ctx *fiber.Ctx) error {
 }
 
 func (endpoints) apiAdminDeleteElection(ctx *fiber.Ctx) error {
-	if _, ok := getSessionAuth(ctx, authAdminUser); !ok {
+	if _, status := getSessionAuth(ctx); status&authAdminUser == 0 {
 		return fiber.ErrUnauthorized
 	}
 
@@ -74,7 +74,7 @@ func (endpoints) apiAdminDeleteElection(ctx *fiber.Ctx) error {
 }
 
 func (endpoints) apiAdminStartElection(ctx *fiber.Ctx) error {
-	if _, ok := getSessionAuth(ctx, authAdminUser); !ok {
+	if _, status := getSessionAuth(ctx); status&authAdminUser == 0 {
 		return fiber.ErrUnauthorized
 	}
 
@@ -155,7 +155,7 @@ func (endpoints) apiAdminStartElection(ctx *fiber.Ctx) error {
 }
 
 func (endpoints) apiAdminStopElection(ctx *fiber.Ctx) error {
-	if _, ok := getSessionAuth(ctx, authAdminUser); !ok {
+	if _, status := getSessionAuth(ctx); status&authAdminUser == 0 {
 		return fiber.ErrUnauthorized
 	}
 
@@ -241,7 +241,7 @@ func (endpoints) apiAdminStopElection(ctx *fiber.Ctx) error {
 }
 
 func (endpoints) apiAdminRunningElectionSSE(ctx *fiber.Ctx) error {
-	if _, ok := getSessionAuth(ctx, authAdminUser); !ok {
+	if _, status := getSessionAuth(ctx); status&authAdminUser == 0 {
 		return fiber.ErrUnauthorized
 	}
 

--- a/internal/httpcore/endpoints_adminapi_users.go
+++ b/internal/httpcore/endpoints_adminapi_users.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (endpoints) apiAdminDeleteUser(ctx *fiber.Ctx) error {
-	if _, isAuthed := getSessionAuth(ctx, authAdminUser); !isAuthed {
+	if _, status := getSessionAuth(ctx); status&authAdminUser == 0 {
 		return fiber.ErrUnauthorized
 	}
 
@@ -48,7 +48,7 @@ func (endpoints) apiAdminDeleteUser(ctx *fiber.Ctx) error {
 }
 
 func (endpoints) apiAdminListUsers(ctx *fiber.Ctx) error {
-	if _, isAuthed := getSessionAuth(ctx, authAdminUser); !isAuthed {
+	if _, status := getSessionAuth(ctx); status&authAdminUser == 0 {
 		return fiber.ErrUnauthorized
 	}
 
@@ -69,7 +69,7 @@ func (endpoints) apiAdminListUsers(ctx *fiber.Ctx) error {
 }
 
 func (endpoints) apiAdminToggleRestrictUser(ctx *fiber.Ctx) error {
-	if _, isAuthed := getSessionAuth(ctx, authAdminUser); !isAuthed {
+	if _, status := getSessionAuth(ctx); status&authAdminUser == 0 {
 		return fiber.ErrUnauthorized
 	}
 

--- a/internal/httpcore/endpoints_adminapi_users.go
+++ b/internal/httpcore/endpoints_adminapi_users.go
@@ -98,6 +98,13 @@ func (endpoints) apiAdminToggleRestrictUser(ctx *fiber.Ctx) error {
 		return fmt.Errorf("apiAdminToggleRestrictUser get user: %w", err)
 	}
 
+	if user.IsAdmin {
+		return &fiber.Error{
+			Code:    fiber.StatusForbidden,
+			Message: "This user is an administrator - administrators cannot be restricted.",
+		}
+	}
+
 	user.IsRestricted = !user.IsRestricted
 
 	if err := user.Update(tx); err != nil {

--- a/internal/httpcore/endpoints_api_self.go
+++ b/internal/httpcore/endpoints_api_self.go
@@ -8,8 +8,8 @@ import (
 )
 
 func (endpoints) apiMe(ctx *fiber.Ctx) error {
-	userID, isAuthed := getSessionAuth(ctx, authRegularUser|authAdminUser)
-	if !isAuthed {
+	userID, authStatus := getSessionAuth(ctx)
+	if authStatus == authNotAuthed {
 		return fiber.ErrUnauthorized
 	}
 
@@ -37,8 +37,8 @@ func (endpoints) apiMe(ctx *fiber.Ctx) error {
 }
 
 func (endpoints) apiSetOwnName(ctx *fiber.Ctx) error {
-	userID, isAuthed := getSessionAuth(ctx, authRegularUser)
-	if !isAuthed {
+	userID, authStatus := getSessionAuth(ctx)
+	if authStatus == authNotAuthed {
 		return fiber.ErrUnauthorized
 	}
 

--- a/internal/httpcore/endpoints_auth.go
+++ b/internal/httpcore/endpoints_auth.go
@@ -37,7 +37,7 @@ func (endpoints) authLogin(ctx *fiber.Ctx) error {
 			goto staticPage
 		}
 
-		if _, err := strconv.Atoi(studentID); err != nil && studentID != "admin" {
+		if _, err := strconv.Atoi(studentID); err != nil {
 			requestProblem = "invalid student ID"
 			goto staticPage
 		}
@@ -46,15 +46,6 @@ func (endpoints) authLogin(ctx *fiber.Ctx) error {
 		if passwordPlaintext == "" {
 			requestProblem = "missing password"
 			goto staticPage
-		}
-
-		if studentID == "admin" {
-			if subtle.ConstantTimeCompare([]byte(config.Get().Platform.AdminToken), []byte(passwordPlaintext)) == 0 {
-				goto incorrectPassword
-			} else {
-				ctx.Cookie(newSessionTokenCookie(signData("admin")))
-				return ctx.Redirect("/")
-			}
 		}
 
 		// Provision user if needed

--- a/internal/httpcore/endpoints_auth.go
+++ b/internal/httpcore/endpoints_auth.go
@@ -52,7 +52,7 @@ func (endpoints) authLogin(ctx *fiber.Ctx) error {
 			if subtle.ConstantTimeCompare([]byte(config.Get().Platform.AdminToken), []byte(passwordPlaintext)) == 0 {
 				goto incorrectPassword
 			} else {
-				ctx.Cookie(newSessionTokenCookie(signData("admin", "admin")))
+				ctx.Cookie(newSessionTokenCookie(signData("admin")))
 				return ctx.Redirect("/")
 			}
 		}
@@ -107,7 +107,7 @@ func (endpoints) authLogin(ctx *fiber.Ctx) error {
 		}
 
 		// Issue token
-		ctx.Cookie(newSessionTokenCookie(signData("token", studentID)))
+		ctx.Cookie(newSessionTokenCookie(signData(studentID)))
 
 		// Redirect to app
 		return ctx.Redirect("/")

--- a/internal/httpcore/endpoints_auth.go
+++ b/internal/httpcore/endpoints_auth.go
@@ -3,6 +3,7 @@ package httpcore
 import (
 	"crypto/sha512"
 	"crypto/subtle"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"github.com/CSSUoB/society-voting/internal/config"
@@ -12,148 +13,252 @@ import (
 	"github.com/gofiber/fiber/v2"
 	g "github.com/maragudk/gomponents"
 	"github.com/maragudk/gomponents/html"
-	"strconv"
 )
 
-func (endpoints) authLogin(ctx *fiber.Ctx) error {
-	var requestProblem string
-
-	switch ctx.Method() {
-	case fiber.MethodGet:
-		goto staticPage
-	case fiber.MethodPost:
-		break
-	default:
-		return fiber.ErrMethodNotAllowed
-	}
-
-	if method := ctx.Method(); method == fiber.MethodGet {
-		goto staticPage
-	} else if method == fiber.MethodPost {
-		// Process form with <studentid> field
-		studentID := ctx.FormValue("studentid")
-		if studentID == "" {
-			requestProblem = "missing student ID"
-			goto staticPage
-		}
-
-		if _, err := strconv.Atoi(studentID); err != nil {
-			requestProblem = "invalid student ID"
-			goto staticPage
-		}
-
-		passwordPlaintext := ctx.FormValue("password")
-		if passwordPlaintext == "" {
-			requestProblem = "missing password"
-			goto staticPage
-		}
-
-		// Provision user if needed
-
-		tx, err := database.GetTx()
-		if err != nil {
-			return fmt.Errorf("authLogin start tx: %w", err)
-		}
-		defer tx.Rollback()
-
-		user, err := database.GetUser(studentID, tx)
-		if err != nil {
-			if !errors.Is(err, database.ErrNotFound) {
-				return fmt.Errorf("authLogin call getUser: %w", err)
-			}
-		}
-
-		passwordHash := sha512.Sum512([]byte(passwordPlaintext))
-
-		if user == nil {
-			// provision user
-
-			guildMember, err := guildScraper.GetMember(studentID)
-			if err != nil {
-				return fmt.Errorf("authLogin membership check: %w", err)
-			}
-
-			if guildMember == nil {
-				requestProblem = "not a member of " + config.Get().Platform.SocietyName
-				goto staticPage
-			}
-
-			user = &database.User{
-				StudentID:    studentID,
-				Name:         guildMember.Name,
-				PasswordHash: passwordHash[:],
-				IsAdmin:      guildMember.IsCommitteeMember,
-			}
-
-			if err := user.Insert(tx); err != nil {
-				return fmt.Errorf("authLogin insert new user: %w", err)
-			}
-		} else {
-			if subtle.ConstantTimeCompare(passwordHash[:], user.PasswordHash) == 0 {
-				goto incorrectPassword
-			}
-		}
-
-		if err := tx.Commit(); err != nil {
-			return fmt.Errorf("authLogin commit tx: %w", err)
-		}
-
-		// Issue token
-		ctx.Cookie(newSessionTokenCookie(signData(studentID)))
-
-		// Redirect to app
-		return ctx.Redirect("/")
-	} else {
-		return fiber.ErrMethodNotAllowed
-	}
-
-incorrectPassword:
-	requestProblem = "incorrect password (speak to a member of committee if you've forgotten your password)"
-
-staticPage:
-	// GET request: serve page
-
+func (endpoints) authLoginPage(ctx *fiber.Ctx) error {
 	titleLine := config.Get().Platform.SocietyName + " voting"
 	page := htmlutil.SkeletonPage(titleLine,
 		html.H1(g.Text(titleLine)),
 		html.P(g.Text("Please enter your details. Please note you must be a member to proceed.")),
-		html.P(g.Text("If you have not logged in before, please choose a password and enter it here, otherwise use your existing password.")),
-		g.If(requestProblem != "",
-			html.P(g.Textf("Error: %s", requestProblem), g.Attr("style", "color: red")),
+		//g.If(requestProblem != "",
+		//	html.P(g.Textf("Error: %s", requestProblem), g.Attr("style", "color: red")),
+		//),
+		html.Script(g.Attr("src", "https://unpkg.com/htmx.org@1.9.10"), g.Attr("defer")),
+		html.Div(
+			g.Attr("hx-get", loginActionEndpoint),
+			g.Attr("hx-trigger", "load"),
+			g.Attr("hx-swap", "outerHTML"),
+			//g.Text("Loading..."),
 		),
-		html.FormEl(
-			g.Attr("method", "POST"),
-			html.Label(
-				g.Text("Student ID"),
-				g.Attr("for", "student-id-input"),
-				g.Attr("style", "margin-right: 6px"),
-			),
-			html.Input(
-				g.Attr("type", "text"),
-				g.Attr("id", "student-id-input"),
-				g.Attr("placeholder", "Student ID"),
-				g.Attr("name", "studentid"),
-			),
-			html.Br(),
-			html.Label(
-				g.Text("Password"),
-				g.Attr("for", "password-input"),
-				g.Attr("style", "margin-right: 6px"),
-			),
-			html.Input(
-				g.Attr("type", "password"),
-				g.Attr("placeholder", "Password"),
-				g.Attr("name", "password"),
-			),
-			html.Br(),
-			html.Input(
-				g.Attr("type", "submit"),
-				g.Attr("value", "Submit"),
-			),
-		),
+		html.P(g.Attr("class", "htmx-indicator"), g.Attr("id", "indicator"), g.Text("Working...")),
 	)
 
 	return htmlutil.SendPage(ctx, page)
+}
+
+func (endpoints) authLogin(ctx *fiber.Ctx) error {
+	var requestProblem string
+
+	var requestData = struct {
+		StudentID            string `json:"studentid,omitempty"`
+		Password             string `json:"password,omitempty"`
+		PasswordConfirmation string `json:"passwordconf,omitempty"`
+		FirstName            string `json:"fname,omitempty"`
+		LastName             string `json:"lname,omitempty"`
+		AuthCode             string `json:"auth,omitempty"`
+	}{
+		StudentID:            ctx.FormValue("studentid"),
+		Password:             ctx.FormValue("password"),
+		PasswordConfirmation: ctx.FormValue("passwordconf"),
+		FirstName:            ctx.FormValue("fname"),
+		LastName:             ctx.FormValue("lname"),
+		AuthCode:             ctx.FormValue("auth"),
+	}
+
+	requestDataJSON, err := json.Marshal(&requestData)
+	if err != nil {
+		return fmt.Errorf("authLogin marshal request data to JSON: %w", err)
+	}
+
+	if ctx.Method() == fiber.MethodGet {
+		goto askStudentID
+	}
+
+	{
+		// Has SID?
+		if requestData.StudentID == "" {
+			// No: show form
+			goto askStudentID
+		}
+
+		var passwordHash [64]byte
+		if requestData.Password != "" {
+			passwordHash = sha512.Sum512([]byte(requestData.Password))
+		}
+
+		// SID already registered?
+		user, err := database.GetUser(requestData.StudentID)
+		if err != nil && !errors.Is(err, database.ErrNotFound) {
+			return fmt.Errorf("authLogin get user: %w", err)
+		}
+		if user != nil {
+			// Yes: has password?
+			if requestData.Password != "" {
+				// Yes: Is password valid?
+				if subtle.ConstantTimeCompare(passwordHash[:], user.PasswordHash) == 1 {
+					// Yes: issue token, redirect
+					goto success
+				}
+
+				// No: return to start with error
+				requestProblem = "Invalid password - that password did not match the password that is stored for that student ID."
+				goto reset
+			} else {
+				// No: show form
+				goto registeredAskPassword
+			}
+		}
+
+		guildMember, err := guildScraper.GetMember(requestData.StudentID)
+		if err != nil {
+			return fmt.Errorf("authLogin get guild member: %w", err)
+		}
+		if guildMember == nil {
+			requestProblem = "Invalid student ID - it doesn't look like that student ID corresponds to a " + config.Get().Platform.SocietyName + " member."
+			goto reset
+		}
+
+		// Has names?
+		if requestData.FirstName == "" && requestData.LastName == "" {
+			// No: show names form
+			goto askNames
+		}
+
+		fmt.Println(requestData.FirstName, guildMember.FirstName)
+		fmt.Println(requestData.LastName, guildMember.LastName)
+
+		if subtle.ConstantTimeCompare([]byte(requestData.FirstName), []byte(guildMember.FirstName)) == 0 ||
+			subtle.ConstantTimeCompare([]byte(requestData.LastName), []byte(guildMember.LastName)) == 0 {
+			requestProblem = "Invalid name - please ensure that you are using the name the Guild of Students knows you as."
+			goto reset
+		}
+
+		// Will be an admin?
+		if guildMember.IsCommitteeMember {
+			// Yes: has auth code?
+			if requestData.AuthCode == "" {
+				// No: show form
+				goto askAuthCode
+			}
+
+			if subtle.ConstantTimeCompare([]byte(requestData.AuthCode), []byte(config.Get().Platform.AdminToken)) == 0 {
+				requestProblem = "Invalid admin token."
+				goto reset
+			}
+		}
+
+		fmt.Printf("%#v\n", requestData)
+
+		// Has password and password confirmation?
+		if requestData.PasswordConfirmation == "" || requestData.Password == "" {
+			// No: show form
+			goto unregisteredAskPassword
+		}
+
+		if requestData.PasswordConfirmation != requestData.Password {
+			requestProblem = "Passwords do not match."
+			goto unregisteredAskPassword
+		}
+
+		user = &database.User{
+			StudentID:    requestData.StudentID,
+			Name:         guildMember.FirstName + " " + guildMember.LastName,
+			PasswordHash: passwordHash[:],
+			IsAdmin:      guildMember.IsCommitteeMember,
+		}
+
+		if err := user.Insert(); err != nil {
+			return fmt.Errorf("authLogin insert new user: %w", err)
+		}
+	}
+
+success:
+	ctx.Cookie(newSessionTokenCookie(signData(requestData.StudentID)))
+	ctx.Set("HX-Redirect", "/")
+	ctx.Status(fiber.StatusNoContent)
+	return nil
+
+reset:
+askStudentID:
+	return htmlutil.SendFragment(ctx, html.FormEl(
+		g.Attr("hx-indicator", "#indicator"),
+		g.Attr("hx-post", loginActionEndpoint),
+		g.Attr("hx-swap", "outerHTML"),
+		g.If(requestProblem != "", html.P(
+			g.Attr("style", "color: red;"),
+			html.Em(g.Text(requestProblem+" If you're having trouble logging in, please speak to a member of committee.")),
+		)),
+		html.H2(g.Text("What's your student ID?")),
+		htmlutil.FormInput("text", "studentid", "Your student ID", "Student ID"),
+		html.Br(),
+		html.Input(
+			g.Attr("type", "submit"),
+			g.Attr("value", "Next"),
+		),
+	))
+
+registeredAskPassword:
+	return htmlutil.SendFragment(ctx, html.FormEl(
+		g.Attr("hx-indicator", "#indicator"),
+		g.Attr("hx-post", loginActionEndpoint),
+		g.Attr("hx-swap", "outerHTML"),
+		g.Attr("hx-vals", string(requestDataJSON)),
+		html.H2(g.Text("Welcome back!")),
+		html.P(g.Text("Please enter your password. If you've forgotten it, please speak to a member of committee.")),
+		htmlutil.FormInput("password", "password", "", "Password"),
+		html.Br(),
+		html.Input(
+			g.Attr("type", "submit"),
+			g.Attr("value", "Next"),
+		),
+	))
+
+askNames:
+	return htmlutil.SendFragment(ctx, html.FormEl(
+		g.Attr("hx-indicator", "#indicator"),
+		g.Attr("hx-post", loginActionEndpoint),
+		g.Attr("hx-swap", "outerHTML"),
+		g.Attr("hx-vals", string(requestDataJSON)),
+		html.H2(g.Text("Welcome!")),
+		html.P(g.Text("In order to check that the student ID you entered is yours, please enter your name as the Guild of Students knows it.")),
+		htmlutil.FormInput("text", "fname", "Your first name", "First name"),
+		html.Br(),
+		htmlutil.FormInput("text", "lname", "Your last name", "Last name"),
+		html.Br(),
+		html.Input(
+			g.Attr("type", "submit"),
+			g.Attr("value", "Next"),
+		),
+	))
+
+askAuthCode:
+	return htmlutil.SendFragment(ctx, html.FormEl(
+		g.Attr("hx-indicator", "#indicator"),
+		g.Attr("hx-post", loginActionEndpoint),
+		g.Attr("hx-swap", "outerHTML"),
+		g.Attr("hx-vals", string(requestDataJSON)),
+		html.H2(g.Text("Welcome!")),
+		html.P(g.Text("Please enter the authorisation code.")),
+		htmlutil.FormInput("text", "auth", "", "Authorisation code"),
+		html.Br(),
+		html.Input(
+			g.Attr("type", "submit"),
+			g.Attr("value", "Next"),
+		),
+	))
+
+unregisteredAskPassword:
+	return htmlutil.SendFragment(ctx, html.FormEl(
+		g.Attr("hx-indicator", "#indicator"),
+		g.Attr("hx-post", loginActionEndpoint),
+		g.Attr("hx-swap", "outerHTML"),
+		g.Attr("hx-vals", string(requestDataJSON)),
+		g.If(requestProblem != "", html.P(
+			g.Attr("style", "color: red;"),
+			html.Em(g.Text(requestProblem)),
+		)),
+		html.H2(g.Text("Welcome!")),
+		html.P(g.Text("Please choose a password.")),
+		htmlutil.FormInput("password", "password", "", "Password"),
+		html.Br(),
+		htmlutil.FormInput("password", "passwordconf", "", "Confirm password"),
+		html.Br(),
+		html.Input(
+			g.Attr("type", "submit"),
+			g.Attr("value", "Next"),
+		),
+	))
+
 }
 
 func (endpoints) authLogout(ctx *fiber.Ctx) error {

--- a/internal/httpcore/endpoints_auth.go
+++ b/internal/httpcore/endpoints_auth.go
@@ -82,6 +82,7 @@ func (endpoints) authLogin(ctx *fiber.Ctx) error {
 				StudentID:    studentID,
 				Name:         guildMember.Name,
 				PasswordHash: passwordHash[:],
+				IsAdmin:      guildMember.IsCommitteeMember,
 			}
 
 			if err := user.Insert(tx); err != nil {

--- a/internal/httpcore/endpoints_presenter.go
+++ b/internal/httpcore/endpoints_presenter.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (endpoints) presenterQRCode(ctx *fiber.Ctx) error {
-	if _, isAuthed := getSessionAuth(ctx, authAdminUser); !isAuthed {
+	if _, status := getSessionAuth(ctx); status&authAdminUser == 0 {
 		return fiber.ErrUnauthorized
 	}
 
@@ -26,7 +26,7 @@ func (endpoints) presenterQRCode(ctx *fiber.Ctx) error {
 var presenterPageHTML string
 
 func (endpoints) presenterPage(ctx *fiber.Ctx) error {
-	if _, isAuthed := getSessionAuth(ctx, authAdminUser); !isAuthed {
+	if _, status := getSessionAuth(ctx); status&authAdminUser == 0 {
 		return fiber.ErrUnauthorized
 	}
 

--- a/internal/httpcore/htmlutil/skeleton.go
+++ b/internal/httpcore/htmlutil/skeleton.go
@@ -5,6 +5,8 @@ import (
 	"github.com/gofiber/fiber/v2"
 	g "github.com/maragudk/gomponents"
 	. "github.com/maragudk/gomponents/html"
+	"math/rand"
+	"strconv"
 )
 
 func SkeletonPage(title string, content ...g.Node) g.Node {
@@ -31,4 +33,28 @@ func SendPage(ctx *fiber.Ctx, page g.Node) error {
 	_ = page.Render(buf)
 	ctx.Type("html")
 	return ctx.SendStream(buf)
+}
+
+func SendFragment(ctx *fiber.Ctx, frag g.Node) error {
+	buf := new(bytes.Buffer)
+	_ = frag.Render(buf)
+	ctx.Type("html")
+	return ctx.SendStream(buf)
+}
+
+func FormInput(inputType, name, placeholder, labelText string) g.Node {
+	r := strconv.Itoa(rand.Intn(1000000))
+	return g.Group([]g.Node{
+		Label(
+			g.Text(labelText),
+			g.Attr("for", r),
+			g.Attr("style", "margin-right: 6px"),
+		),
+		Input(
+			g.Attr("type", inputType),
+			g.Attr("placeholder", placeholder),
+			g.Attr("name", name),
+			g.Attr("id", r),
+		),
+	})
 }

--- a/internal/httpcore/httpcore.go
+++ b/internal/httpcore/httpcore.go
@@ -26,6 +26,8 @@ import (
 
 type endpoints struct{}
 
+const loginActionEndpoint = "/auth/login/do"
+
 func ListenAndServe(addr string) error {
 	app := fiber.New(fiber.Config{
 		ErrorHandler: func(ctx *fiber.Ctx, err error) error {
@@ -86,8 +88,11 @@ func ListenAndServe(addr string) error {
 		},
 	}))
 
+	app.Get("/auth/login", e.authLoginPage)
+	app.Post("/auth/login", e.authLoginPage)
 	app.Get("/auth/login", e.authLogin)
 	app.Post("/auth/login", e.authLogin)
+
 	app.Get("/auth/logout", e.authLogout)
 
 	app.Get("/api/me", e.apiMe)

--- a/internal/httpcore/httpcore.go
+++ b/internal/httpcore/httpcore.go
@@ -70,12 +70,12 @@ func ListenAndServe(addr string) error {
 	app.Use(limiter.New(limiter.Config{
 		Next: func(ctx *fiber.Ctx) bool {
 			p := ctx.Path()
-			user, authStatus := getSessionAuth(ctx)
-			return authStatus == authNotAuthed || user == "admin" || p == "/" || urlFileRegexp.MatchString(p)
+			_, authStatus := getSessionAuth(ctx)
+			return authStatus == authNotAuthed || p == "/" || urlFileRegexp.MatchString(p)
 		},
 		Max: 45,
 		KeyGenerator: func(ctx *fiber.Ctx) string {
-			// only set if authed which we are if it's passed the Next check
+			// only set if authed, which we are if it's passed the Next check
 			return ctx.Locals("token").(string)
 		},
 		LimitReached: func(ctx *fiber.Ctx) error {

--- a/internal/httpcore/httpcore.go
+++ b/internal/httpcore/httpcore.go
@@ -90,8 +90,8 @@ func ListenAndServe(addr string) error {
 
 	app.Get("/auth/login", e.authLoginPage)
 	app.Post("/auth/login", e.authLoginPage)
-	app.Get("/auth/login", e.authLogin)
-	app.Post("/auth/login", e.authLogin)
+	app.Get(loginActionEndpoint, e.authLogin)
+	app.Post(loginActionEndpoint, e.authLogin)
 
 	app.Get("/auth/logout", e.authLogout)
 

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -33,7 +33,7 @@
 		withCredentials: true,
 	});
 	const electionStatusChanged = async () => {
-		if (!$user.admin) {
+		if (!$user.isAdmin) {
 			$elections = await _getElections();
 			$currentElection = await _getCurrentElection();
 		}
@@ -48,11 +48,11 @@
 	<main style:left={menuOpen ? "0" : ""}>
 		<div class="rail">
 			<Profile />
-			{#if !data.user.admin && $currentElection && !$currentElection.hasVoted}
+			{#if $currentElection && (!$currentElection.hasVoted || $user.isAdmin)}
 				<Current />
 			{/if}
 			<Upcoming />
-			{#if data.user.admin}
+			{#if data.user.isAdmin}
 				<Users />
 				<PresenterMode />
 			{/if}

--- a/web/src/routes/+layout.ts
+++ b/web/src/routes/+layout.ts
@@ -7,7 +7,7 @@ export async function load({ fetch, params }) {
     const [user, elections, currentElection] = await Promise.all([_getUser(), _getElections(), _getCurrentElection()]);
 
     return {
-        user: { ...user, admin: user.studentID === "admin" },
+        user,
         elections,
         currentElection
     };

--- a/web/src/routes/current.svelte
+++ b/web/src/routes/current.svelte
@@ -2,22 +2,39 @@
 	import { goto } from "$app/navigation";
 	import Button from "$lib/button.svelte";
 	import Panel from "$lib/panel.svelte";
-	import { elections } from "../store";
+	import { currentElection, elections, user } from "../store";
 	$: current = $elections?.find((e) => e.isActive);
 </script>
 
 <Panel title="Vote now!" kind="emphasis" headerIcon="how_to_vote">
-	<div>
+	<div class="container">
 		<h3>Voting is now open for: {current?.roleName}</h3>
-		<Button icon="arrow_forward" text="Vote now" kind="primary" on:click={() => goto(`/vote`)} />
+		<div class="actions">
+			{#if !$currentElection?.hasVoted}
+				<Button
+					icon="arrow_forward"
+					text="Vote now"
+					kind="primary"
+					on:click={() => goto(`/vote`)}
+				/>
+			{/if}
+			{#if $user.isAdmin}
+				<Button text="Manage election" kind="emphasis" on:click={() => goto(`/stats`)} />
+			{/if}
+		</div>
 	</div>
 </Panel>
 
 <style>
-	div {
+	div.container,
+	div.actions {
 		display: flex;
 		flex-direction: column;
 		gap: 8px;
 		align-items: flex-start;
+	}
+
+	div.actions {
+		flex-direction: row;
 	}
 </style>

--- a/web/src/routes/election/[eid]/+page.svelte
+++ b/web/src/routes/election/[eid]/+page.svelte
@@ -88,7 +88,7 @@
 	<p>{election?.description}</p>
 </Panel>
 
-{#if !$user.admin && !election?.candidates?.some((c) => c.isMe)}
+{#if !election?.candidates?.some((c) => c.isMe)}
 	<Banner title="Interested in running?" kind="emphasis">
 		<img slot="image" src={run} alt="" class="banner-image" />
 		<svelte:fragment slot="content">
@@ -126,7 +126,7 @@
 	{/if}
 </Panel>
 
-{#if $user.admin}
+{#if $user.isAdmin}
 	<Panel title="Admin stuff" headerIcon="admin_panel_settings">
 		<div class="admin-controls">
 			<h3>Candidates standing from the floor</h3>

--- a/web/src/routes/profile.svelte
+++ b/web/src/routes/profile.svelte
@@ -27,9 +27,7 @@
 
 <Panel title="Hi {$user.name.split(' ')[0]}!" headerIcon="waving_hand">
 	<svelte:fragment slot="header-action">
-		{#if !$user.admin}
-			<Button text="Use a different name" kind="emphasis" on:click={() => dialog.showModal()} />
-		{/if}
+		<Button text="Use a different name" kind="emphasis" on:click={() => dialog.showModal()} />
 	</svelte:fragment>
 	<p>Welcome to CSS' voting system! View, stand for, and vote in currently running elections.</p>
 	<br />

--- a/web/src/routes/stats/+page.svelte
+++ b/web/src/routes/stats/+page.svelte
@@ -11,7 +11,7 @@
 	let numberOfVotes = 0;
 	let dialog: HTMLDialogElement;
 
-	$: if (!$currentElection) {
+	if (!$currentElection) {
 		goto("/");
 	}
 
@@ -34,6 +34,7 @@
 		}
 		electionRunning = false;
 		results = (await response.json()).result;
+		$currentElection = null;
 		$fetching = false;
 	};
 
@@ -67,8 +68,10 @@
 		<div class="container">
 			<h3>{numberOfVotes} of {$currentElection?.numEligibleVoters} users have voted so far</h3>
 			<p>
-				The turnout so far is {((numberOfVotes * 100) /
-					($currentElection?.numEligibleVoters ?? 100)).toFixed(2)}%
+				The turnout so far is {(
+					(numberOfVotes * 100) /
+					($currentElection?.numEligibleVoters ?? 100)
+				).toFixed(2)}%
 			</p>
 			<Button
 				text="End election and view results"

--- a/web/src/routes/stats/+page.svelte
+++ b/web/src/routes/stats/+page.svelte
@@ -34,7 +34,6 @@
 		}
 		electionRunning = false;
 		results = (await response.json()).result;
-		$currentElection = null;
 		$fetching = false;
 	};
 
@@ -52,6 +51,7 @@
 		element.click();
 
 		document.body.removeChild(element);
+		$currentElection = null;
 	};
 </script>
 

--- a/web/src/routes/stats/+page.ts
+++ b/web/src/routes/stats/+page.ts
@@ -1,0 +1,9 @@
+import { API } from "$lib/endpoints";
+import { redirect } from "@sveltejs/kit";
+
+export async function load({ fetch, params }) {
+    const response = await fetch(API.ADMIN_USER);
+    if (!response.ok) {
+        throw redirect(302, "/");
+    }
+}

--- a/web/src/routes/upcoming.svelte
+++ b/web/src/routes/upcoming.svelte
@@ -38,7 +38,7 @@
 			<Button icon="arrow_forward" on:click={() => goto(`/election/${election.id}`)} />
 		</li>
 	</List>
-	{#if $user.admin}
+	{#if $user.isAdmin}
 		<Button
 			kind="emphasis"
 			text="Create a new election"

--- a/web/src/routes/users/+page.svelte
+++ b/web/src/routes/users/+page.svelte
@@ -71,13 +71,21 @@
 		<li class="user" class:restricted={user.isRestricted}>
 			<p>{user.studentID}</p>
 			<p>
-				{user.name}{#if user.isRestricted} <span class="pill"><small>Restricted</small></span>{/if}
+				{user.name}
+				{#if user.isRestricted}
+					<span class="pill pill--red"><small>Restricted</small></span>
+				{/if}
+				{#if user.isAdmin}
+					<span class="pill pill--black"><small>Admin</small></span>
+				{/if}
 			</p>
-			<Button
-				icon={user.isRestricted ? "check" : "block"}
-				text={user.isRestricted ? "Unrestrict user" : "Restrict user"}
-				on:click={confirmRestrictUser.bind(null, user)}
-			/>
+			{#if !user.isAdmin}
+				<Button
+					icon={user.isRestricted ? "check" : "block"}
+					text={user.isRestricted ? "Unrestrict user" : "Restrict user"}
+					on:click={confirmRestrictUser.bind(null, user)}
+				/>
+			{/if}
 			<Button
 				icon="person_remove"
 				text="Delete user"
@@ -144,12 +152,19 @@
 
 	li.user p > span.pill {
 		margin-left: 8px;
-		background: rgba(255, 0, 0, 0.5);
 		color: #fff;
 		padding: 0 8px;
 		border-radius: 4px;
 		text-transform: uppercase;
 		font-family: "JetBrains Mono";
 		font-weight: bold;
+	}
+
+	li.user p > span.pill--red {
+		background: rgba(255, 0, 0, 0.5);
+	}
+
+	li.user p > span.pill--black {
+		background: black;
 	}
 </style>

--- a/web/src/routes/users/+page.svelte
+++ b/web/src/routes/users/+page.svelte
@@ -43,9 +43,8 @@
 			body: JSON.stringify({ userID }),
 		});
 
-		const j = await response.json();
-
 		if (response.ok) {
+			const j = await response.json();
 			data = {
 				...data,
 				users: data.users.map((u) => {

--- a/web/src/routes/vote/+page.svelte
+++ b/web/src/routes/vote/+page.svelte
@@ -62,35 +62,37 @@
 	<p>{$currentElection?.election.description}</p>
 </Panel>
 
-{#if !$user.admin}
-	<Panel title="Your ballot">
-		<p>There are {($currentElection?.ballot.length ?? 1) - 1} candidates on the ballot.</p>
-		<p>Rank candidates in order of your choice. You do not need to rank all candidates.</p>
-		<List items={ballot} let:prop={candidate}>
-			<BallotEntry
-				ballot={$currentElection?.ballot ?? []}
-				{candidate}
-				error={errors[candidate.index]}
-				on:change={(e) => updateAndValidate(candidate.index, e)}
-			/>
-		</List>
-	</Panel>
+<Panel title="Your ballot">
+	<p>There are {($currentElection?.ballot.length ?? 1) - 1} candidates on the ballot.</p>
+	<p>Rank candidates in order of your choice. You do not need to rank all candidates.</p>
+	<List items={ballot} let:prop={candidate}>
+		<BallotEntry
+			ballot={$currentElection?.ballot ?? []}
+			{candidate}
+			error={errors[candidate.index]}
+			on:change={(e) => updateAndValidate(candidate.index, e)}
+		/>
+	</List>
+</Panel>
 
-	<Panel title="Submit" kind="emphasis">
-		<div class="submit-container">
-			<input bind:this={codeInput} placeholder="Enter election code" type="text" />
-			<Button
-				kind="primary"
-				text="Submit vote"
-				icon="check"
-				on:click={() => submit()}
-				disabled={errors.filter((x) => x).length > 0}
-			/>
-		</div>
-	</Panel>
-{/if}
+<Panel title="Submit" kind="emphasis">
+	<div class="submit-container">
+		<input bind:this={codeInput} placeholder="Enter election code" type="text" />
+		<Button
+			kind="primary"
+			text="Submit vote"
+			icon="check"
+			on:click={() => submit()}
+			disabled={errors.filter((x) => x).length > 0}
+		/>
+	</div>
+</Panel>
 
-<Dialog title="Congrats, you've voted!" bind:dialog={votedDialog} on:close={() => goto("/")}>
+<Dialog
+	title="Congrats, you've voted!"
+	bind:dialog={votedDialog}
+	on:close={() => goto($user.isAdmin ? "/stats" : "/")}
+>
 	<div class="dialog-container">
 		<img src={`https://cssuob.github.io/resources/dinosaur/tex_ballot.svg`} width="200px" />
 		<p>

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -4,7 +4,7 @@ import { writable } from 'svelte/store'
 export interface User {
     name: string;
     studentID: string;
-    admin: boolean;
+    isAdmin: boolean;
     isRestricted: boolean;
 }
 


### PR DESCRIPTION
Little backend to do list:
* [x] alter guild membership parsing logic to use headers instead of magic number IDs
* [x] alter guild membership parsing logic to include an IsCommitteeMember field in result
* [x] add `IsAdmin` field to user DB schema
* [x] prevent admins from being restricted
* [x] when registering for the first time, get users to confirm their name as known by the guild
* [x] when registering for the first time, get users that will be admins to confirm a registration auth code set in the config
* [x] update user info endpoint
* [x] remove global admin account
* [x] alter session checking logic

optional but useful:
* [x] add admin pill to users list