### PR TITLE
Treat errors when refreshing cached membership as warnings

### DIFF
--- a/internal/guildScraper/checkMember.go
+++ b/internal/guildScraper/checkMember.go
@@ -27,6 +27,8 @@ func GetMember(studentID string) (*GuildMember, error) {
 		if err == nil {
 			cachedMembershipList = members
 			cachedMembershipListLastRefreshed = time.Now()
+		} else if cachedMembershipListLastRefreshed.IsZero() {
+			return fmt.Errorf("initially load membership list: %w", err)
 		} else {
 			slog.Warn("failed to refresh cached membership list", "error", err)
 		}

--- a/internal/guildScraper/checkMember.go
+++ b/internal/guildScraper/checkMember.go
@@ -4,6 +4,7 @@ package guildScraper
 
 import (
 	"fmt"
+	"log/slog"
 	"sync"
 	"time"
 )
@@ -19,20 +20,18 @@ func GetMember(studentID string) (*GuildMember, error) {
 
 	if time.Now().Sub(cachedMembershipListLastRefreshed) > time.Minute*5 {
 		cachedMembershipListLock.RUnlock()
-
 		cachedMembershipListLock.Lock()
+
 		members, err := GetMembersList()
 
-		if err != nil {
-			cachedMembershipListLock.Unlock()
-			return nil, fmt.Errorf("refresh cached membership list: %w", err)
+		if err == nil {
+			cachedMembershipList = members
+			cachedMembershipListLastRefreshed = time.Now()
+		} else {
+			slog.Warn("failed to refresh cached membership list", "error", err)
 		}
 
-		cachedMembershipList = members
-		cachedMembershipListLastRefreshed = time.Now()
-
 		cachedMembershipListLock.Unlock()
-
 		cachedMembershipListLock.RLock()
 	}
 

--- a/internal/guildScraper/checkMember.go
+++ b/internal/guildScraper/checkMember.go
@@ -28,7 +28,8 @@ func GetMember(studentID string) (*GuildMember, error) {
 			cachedMembershipList = members
 			cachedMembershipListLastRefreshed = time.Now()
 		} else if cachedMembershipListLastRefreshed.IsZero() {
-			return fmt.Errorf("initially load membership list: %w", err)
+			cachedMembershipListLock.Unlock()
+			return nil, fmt.Errorf("initially load membership list: %w", err)
 		} else {
 			slog.Warn("failed to refresh cached membership list", "error", err)
 		}


### PR DESCRIPTION
I have not tested this because I can't

But I think it'd work