### PR TITLE
Replace `time.Now().Sub(x)` with `time.Since(x)` - S1012

### DIFF
--- a/internal/guildScraper/checkMember.go
+++ b/internal/guildScraper/checkMember.go
@@ -18,7 +18,7 @@ var (
 func GetMember(studentID string) (*GuildMember, error) {
 	cachedMembershipListLock.RLock()
 
-	if time.Now().Sub(cachedMembershipListLastRefreshed) > time.Minute*5 {
+	if time.Since(cachedMembershipListLastRefreshed) > time.Minute*5 {
 		cachedMembershipListLock.RUnlock()
 		cachedMembershipListLock.Lock()
 


### PR DESCRIPTION
https://staticcheck.dev/docs/checks/#S1012
